### PR TITLE
Add 'source system' as an path input

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,14 +4,14 @@ object Dependencies {
   private val http4sVersion = "0.23.26"
   private val mockitoVersion = "1.17.37"
   private val pureConfigVersion = "0.17.7"
-  private val tapirVersion = "1.10.12"
+  private val tapirVersion = "1.10.15"
 
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.205"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.208"
 
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.4"
 
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.377"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.168"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.382"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.173"
 
   lazy val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   lazy val http4sEmberServer = "org.http4s" %% "http4s-ember-server" % http4sVersion
@@ -19,7 +19,7 @@ object Dependencies {
 
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.16.0"
 
-  lazy val logBackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "7.4"
+  lazy val logBackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "8.0"
   lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.5.6"
 
   lazy val mockito = "org.mockito" %% "mockito-scala" % mockitoVersion

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/controllers/BaseController.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/controllers/BaseController.scala
@@ -4,12 +4,15 @@ import cats.effect.IO
 import sttp.model.StatusCode
 import sttp.tapir.json.circe.jsonBody
 import sttp.tapir.server.PartialServerEndpoint
-import sttp.tapir.{Endpoint, auth, endpoint, statusCode}
+import sttp.tapir.{Endpoint, EndpointInput, auth, endpoint, path, statusCode}
 import uk.gov.nationalarchives.tdr.transfer.service.api.auth.{AuthenticatedContext, TokenAuthenticator}
 import uk.gov.nationalarchives.tdr.transfer.service.api.errors.BackendException.AuthenticationError
 import uk.gov.nationalarchives.tdr.transfer.service.api.model.Serializers._
+import uk.gov.nationalarchives.tdr.transfer.service.api.model.SourceSystem.SourceSystemEnum.SourceSystem
 
 trait BaseController {
+
+  val sourceSystem: EndpointInput[SourceSystem] = path("sourceSystem")
 
   private val tokenAuthenticator = TokenAuthenticator()
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/Serializers.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/Serializers.scala
@@ -1,9 +1,17 @@
 package uk.gov.nationalarchives.tdr.transfer.service.api.model
 
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.AutoDerivation
+import sttp.tapir.Schema
 import sttp.tapir.generic.auto.SchemaDerivation
 import sttp.tapir.generic.{Configuration => TapirConfiguration}
+import uk.gov.nationalarchives.tdr.transfer.service.api.model.SourceSystem.SourceSystemEnum
+import uk.gov.nationalarchives.tdr.transfer.service.api.model.SourceSystem.SourceSystemEnum.SourceSystem
 
 object Serializers extends AutoDerivation with SchemaDerivation {
   implicit val schemaConfiguration: TapirConfiguration = TapirConfiguration.default.withDiscriminator("type")
+
+  implicit val sourceSystemEnc: Encoder[SourceSystem] = Encoder.encodeEnumeration(SourceSystemEnum)
+  implicit val genderDec: Decoder[SourceSystem] = Decoder.decodeEnumeration(SourceSystemEnum)
+  implicit val genderSch: Schema[SourceSystem] = Schema.derivedEnumerationValue[SourceSystem]
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/SourceSystem.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/SourceSystem.scala
@@ -1,0 +1,8 @@
+package uk.gov.nationalarchives.tdr.transfer.service.api.model
+
+object SourceSystem {
+  object SourceSystemEnum extends Enumeration {
+    type SourceSystem = Value
+    val SharePoint: Value = Value("sharepoint")
+  }
+}


### PR DESCRIPTION
This will allow different logic to be used depending on the source of the data. For example using different S3 bucket prefix, triggering different processing steps