### PR TITLE
Tdrsp 31 restrict cors origins

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -29,3 +29,7 @@ transferConfiguration {
     maxNumberRecords = 3000
     maxNumberRecords = ${?MAX_NUMBER_RECORDS}
 }
+
+cors {
+    permittedOrigins = ["sharepoint.com"]
+}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/ApplicationConfig.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/ApplicationConfig.scala
@@ -13,8 +13,17 @@ object ApplicationConfig {
   case class S3(metadataUploadBucket: String, recordsUploadBucket: String)
   case class Schema(dataLoadSharePointLocation: String)
   case class TransferConfiguration(maxNumberRecords: Int)
+  case class Cors(permittedOrigins: List[String])
 
-  case class Configuration(auth: Auth, transferServiceApi: TransferServiceApi, consignmentApi: ConsignmentApi, s3: S3, schema: Schema, transferConfiguration: TransferConfiguration)
+  case class Configuration(
+      auth: Auth,
+      transferServiceApi: TransferServiceApi,
+      consignmentApi: ConsignmentApi,
+      s3: S3,
+      schema: Schema,
+      transferConfiguration: TransferConfiguration,
+      cors: Cors
+  )
 
   val appConfig: Configuration = ConfigSource.default.load[Configuration] match {
     case Left(value)  => throw new RuntimeException(s"Failed to load transfer service application configuration ${value.prettyPrint()}")

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/TransferServiceServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/TransferServiceServer.scala
@@ -54,7 +54,7 @@ object TransferServiceServer extends IOApp {
 
   private val app: Kleisli[IO, Request[IO], Response[IO]] = allRoutes.orNotFound
 
-  private val finalApp = Logger.httpApp(logHeaders = true, logBody = true)(app)
+  private val finalApp = Logger.httpApp(logHeaders = true, logBody = false)(app)
 
   private val transferServiceServer = EmberServerBuilder
     .default[IO]

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/TransferServiceServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/TransferServiceServer.scala
@@ -6,17 +6,18 @@ import cats.implicits.toSemigroupKOps
 import com.comcast.ip4s.{IpLiteralSyntax, Port}
 import org.http4s.dsl.io._
 import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.middleware.{CORS, Logger}
+import org.http4s.server.middleware.Logger
 import org.http4s.{HttpRoutes, Request, Response}
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import sttp.apispec.openapi.Info
 import sttp.client3.{HttpURLConnectionBackend, Identity, SttpBackend}
-import sttp.tapir.server.http4s.Http4sServerInterpreter
+import sttp.tapir.server.http4s.{Http4sServerInterpreter, Http4sServerOptions}
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import uk.gov.nationalarchives.tdr.keycloak.TdrKeycloakDeployment
 import uk.gov.nationalarchives.tdr.transfer.service.ApplicationConfig
 import uk.gov.nationalarchives.tdr.transfer.service.api.controllers.LoadController
+import uk.gov.nationalarchives.tdr.transfer.service.api.cors.CustomCORSInterceptor
 
 object TransferServiceServer extends IOApp {
   implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
@@ -43,21 +44,23 @@ object TransferServiceServer extends IOApp {
     Ok("Healthy")
   }
 
+  private val customServerOptions: Http4sServerOptions[IO] = Http4sServerOptions
+    .customiseInterceptors[IO]
+    .corsInterceptor(CustomCORSInterceptor.apply())
+    .options
+
   private val allRoutes =
-    Http4sServerInterpreter[IO]().toRoutes(documentationEndpoints) <+> loadController.routes <+> healthCheckRoute
+    Http4sServerInterpreter[IO](customServerOptions).toRoutes(documentationEndpoints) <+> loadController.routes <+> healthCheckRoute
 
   private val app: Kleisli[IO, Request[IO], Response[IO]] = allRoutes.orNotFound
 
-  private val finalApp = Logger.httpApp(logHeaders = true, logBody = false)(app)
-
-  private val corsService = CORS.policy
-    .withAllowOriginAll(finalApp)
+  private val finalApp = Logger.httpApp(logHeaders = true, logBody = true)(app)
 
   private val transferServiceServer = EmberServerBuilder
     .default[IO]
     .withHost(ipv4"0.0.0.0")
     .withPort(apiPort)
-    .withHttpApp(corsService)
+    .withHttpApp(finalApp)
     .build
 
   override def run(args: List[String]): IO[ExitCode] = {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/TransferServiceServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/TransferServiceServer.scala
@@ -17,7 +17,7 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import uk.gov.nationalarchives.tdr.keycloak.TdrKeycloakDeployment
 import uk.gov.nationalarchives.tdr.transfer.service.ApplicationConfig
 import uk.gov.nationalarchives.tdr.transfer.service.api.controllers.LoadController
-import uk.gov.nationalarchives.tdr.transfer.service.api.cors.CustomCORSInterceptor
+import uk.gov.nationalarchives.tdr.transfer.service.api.interceptors.CustomInterceptors
 
 object TransferServiceServer extends IOApp {
   implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
@@ -46,7 +46,7 @@ object TransferServiceServer extends IOApp {
 
   private val customServerOptions: Http4sServerOptions[IO] = Http4sServerOptions
     .customiseInterceptors[IO]
-    .corsInterceptor(CustomCORSInterceptor.apply())
+    .corsInterceptor(CustomInterceptors.customCorsInterceptor)
     .options
 
   private val allRoutes =

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/cors/CustomCORSInterceptor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/cors/CustomCORSInterceptor.scala
@@ -1,0 +1,27 @@
+package uk.gov.nationalarchives.tdr.transfer.service.api.cors
+
+import cats.effect.IO
+import sttp.model.{Method, StatusCode}
+import sttp.tapir.server.interceptor.cors.CORSConfig._
+import sttp.tapir.server.interceptor.cors.{CORSConfig, CORSInterceptor}
+import uk.gov.nationalarchives.tdr.transfer.service.ApplicationConfig
+
+object CustomCORSInterceptor {
+  private val permittedOrigins = ApplicationConfig.appConfig.cors.permittedOrigins
+
+  private val corsConfig = CORSConfig.apply(
+    AllowedOrigin.Matching(checkOrigins),
+    AllowedCredentials.Allow,
+    AllowedMethods.Some(Set(Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE)),
+    AllowedHeaders.Reflect,
+    ExposedHeaders.None,
+    maxAge = MaxAge.Default,
+    preflightResponseStatusCode = StatusCode.NoContent
+  )
+
+  private def checkOrigins(origin: String): Boolean = {
+    permittedOrigins.exists(origin.contains)
+  }
+
+  def apply(): CORSInterceptor[IO] = CORSInterceptor.customOrThrow[IO](corsConfig)
+}

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/interceptors/CustomInterceptors.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/interceptors/CustomInterceptors.scala
@@ -1,4 +1,4 @@
-package uk.gov.nationalarchives.tdr.transfer.service.api.cors
+package uk.gov.nationalarchives.tdr.transfer.service.api.interceptors
 
 import cats.effect.IO
 import sttp.model.{Method, StatusCode}
@@ -6,7 +6,7 @@ import sttp.tapir.server.interceptor.cors.CORSConfig._
 import sttp.tapir.server.interceptor.cors.{CORSConfig, CORSInterceptor}
 import uk.gov.nationalarchives.tdr.transfer.service.ApplicationConfig
 
-object CustomCORSInterceptor {
+object CustomInterceptors {
   private val permittedOrigins = ApplicationConfig.appConfig.cors.permittedOrigins
 
   private val corsConfig = CORSConfig.apply(
@@ -23,5 +23,5 @@ object CustomCORSInterceptor {
     permittedOrigins.exists(origin.contains)
   }
 
-  def apply(): CORSInterceptor[IO] = CORSInterceptor.customOrThrow[IO](corsConfig)
+  val customCorsInterceptor: CORSInterceptor[IO] = CORSInterceptor.customOrThrow[IO](corsConfig)
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -21,6 +21,10 @@ schema {
   dataLoadSharePointLocation = "/metadata-schema/dataLoadSharePointSchema.schema.json"
 }
 
+cors {
+    permittedOrigins = ["sharepoint.com"]
+}
+
 transferConfiguration {
     maxNumberRecords = 3000
 }


### PR DESCRIPTION
SharePoint origins use sub-domains

Custom CORS policy to check if the domain is a SharePoint one and allow only those origins

Cannot use wildcard ('*') for the 'access-control-allow-origin' header value as this is not allowed when the request includes credentials include header as SharePoint requests will