### PR TITLE
Provide 'display name' property for metadata fields

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/LoadModel.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/LoadModel.scala
@@ -8,7 +8,7 @@ sealed trait MetadataPropertyModel
 
 object LoadModel {
   case class CustomMetadataConfiguration(required: Boolean = false) extends MetadataPropertyModel
-  case class MetadataPropertyDetails(propertyName: String, required: Boolean) extends MetadataPropertyModel
+  case class MetadataPropertyDetails(propertyName: String, required: Boolean, displayName: String = "") extends MetadataPropertyModel
   case class DisplayMessage(viewName: String, message: String)
   case class TransferConfiguration(
       maxNumberRecords: Int,


### PR DESCRIPTION
SharePoint application will use this value for displaying in the UI, if no value present will default to the property name itself