### PR TITLE
Service to send notifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file("."))
       pureConfig,
       pureConfigCatsEffect,
       scalaTest % Test,
+      snsUtils,
       tapirHttp4sServer,
       tapirJsonCirce,
       tapirSwaggerUI

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,4 +35,5 @@ object Dependencies {
   lazy val tapirSwaggerUI = "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
+  lazy val snsUtils = "uk.gov.nationalarchives" %% "sns-utils" % "0.1.282"
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -25,6 +25,12 @@ s3 {
   recordsUploadBucketName = ${?RECORDS_UPLOAD_BUCKET_NAME}
 }
 
+sns {
+  endpoint = "https://sns.eu-west-2.amazonaws.com/"
+  userEmailSnsTopicArn = "arbitaryPlaceholder"
+  userEmailSnsTopicArn = ${?USER_EMAIL_SNS_TOPIC_ARN}
+}
+
 schema {
   dataLoadSharePointLocation = "/metadata-schema/dataLoadSharePointSchema.schema.json"
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/ApplicationConfig.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/ApplicationConfig.scala
@@ -14,6 +14,7 @@ object ApplicationConfig {
   case class Schema(dataLoadSharePointLocation: String)
   case class TransferConfiguration(maxNumberRecords: Int, maxIndividualFileSizeMb: Int, maxTransferSizeMb: Int)
   case class Cors(permittedOrigins: List[String])
+  case class Sns(endpoint: String, userEmailSnsTopicArn: String)
 
   case class Configuration(
       auth: Auth,
@@ -22,7 +23,8 @@ object ApplicationConfig {
       s3: S3,
       schema: Schema,
       transferConfiguration: TransferConfiguration,
-      cors: Cors
+      cors: Cors,
+      sns: Sns
   )
 
   val appConfig: Configuration = ConfigSource.default.load[Configuration] match {

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/Serializers.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/model/Serializers.scala
@@ -12,6 +12,6 @@ object Serializers extends AutoDerivation with SchemaDerivation {
   implicit val schemaConfiguration: TapirConfiguration = TapirConfiguration.default.withDiscriminator("type")
 
   implicit val sourceSystemEnc: Encoder[SourceSystem] = Encoder.encodeEnumeration(SourceSystemEnum)
-  implicit val genderDec: Decoder[SourceSystem] = Decoder.decodeEnumeration(SourceSystemEnum)
-  implicit val genderSch: Schema[SourceSystem] = Schema.derivedEnumerationValue[SourceSystem]
+  implicit val sourceSystemDec: Decoder[SourceSystem] = Decoder.decodeEnumeration(SourceSystemEnum)
+  implicit val sourceSystemSch: Schema[SourceSystem] = Schema.derivedEnumerationValue[SourceSystem]
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/services/notifications/Notifications.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/services/notifications/Notifications.scala
@@ -1,0 +1,38 @@
+package uk.gov.nationalarchives.tdr.transfer.service.services.notifications
+
+import cats.effect.IO
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.syntax.EncoderOps
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.PublishResponse
+import uk.gov.nationalarchives.aws.utils.sns.SNSClients.sns
+import uk.gov.nationalarchives.aws.utils.sns.SNSUtils
+import uk.gov.nationalarchives.tdr.transfer.service.ApplicationConfig
+import uk.gov.nationalarchives.tdr.transfer.service.services.notifications.Notifications.UploadEvent
+
+class Notifications(snsUtils: SNSUtils, snsConfig: ApplicationConfig.Sns)(implicit logger: SelfAwareStructuredLogger[IO]) {
+  implicit val uploadEventEncoder: Encoder[UploadEvent] = deriveEncoder[UploadEvent]
+
+  def sendUploadEventUserEmail(event: UploadEvent): PublishResponse = {
+    val topicArn = snsConfig.userEmailSnsTopicArn
+    val snsMessage = event.asJson.toString()
+    publishSnsNotification(snsMessage, topicArn)
+  }
+
+  private def publishSnsNotification(message: String, topicArn: String): PublishResponse = {
+    snsUtils.publish(message, topicArn)
+  }
+}
+
+object Notifications {
+  private val snsConfig = ApplicationConfig.appConfig.sns
+  private val snsClient: SnsClient = sns(snsConfig.endpoint)
+  val snsUtils: SNSUtils = SNSUtils(snsClient)
+
+  def apply()(implicit logger: SelfAwareStructuredLogger[IO]) = new Notifications(snsUtils, snsConfig)(logger)
+
+  trait Notification
+  case class UploadEvent(transferringBodyName: String, consignmentReference: String, consignmentId: String, userId: String, userEmail: String, status: String) extends Notification
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -22,6 +22,11 @@ s3 {
   recordsUploadBucketName = "s3BucketNameRecordsName"
 }
 
+sns {
+  endpoint = "http://localhost:9005"
+  userEmailSnsTopicArn = "user-email-sns-topic"
+}
+
 schema {
   dataLoadSharePointLocation = "/metadata-schema/dataLoadSharePointSchema.schema.json"
 }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/services/notifications/NotificationsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/services/notifications/NotificationsSpec.scala
@@ -1,0 +1,28 @@
+package uk.gov.nationalarchives.tdr.transfer.service.services.notifications
+
+import software.amazon.awssdk.services.sns.SnsClient
+import uk.gov.nationalarchives.aws.utils.sns.SNSClients.sns
+import uk.gov.nationalarchives.aws.utils.sns.SNSUtils
+import uk.gov.nationalarchives.tdr.transfer.service.services.notifications.Notifications.UploadEvent
+import uk.gov.nationalarchives.tdr.transfer.service.{ApplicationConfig, BaseSpec}
+
+class NotificationsSpec extends BaseSpec {
+  "'sendUploadEventUserEmail'" should "send the an upload event message to the correct sns topic" in {
+    val mockSnsConfig = mock[ApplicationConfig.Sns]
+    val mockSnsUtils = mock[SNSUtils]
+    when(mockSnsConfig.userEmailSnsTopicArn).thenReturn("user-email-sns-topic")
+    val service = new Notifications(mockSnsUtils, mockSnsConfig)
+    val event = UploadEvent("transferring body name", "consignment reference", "consignment id", "user id", "user@email", "some status")
+    val expectedMessageString = """{
+                                  |  "transferringBodyName" : "transferring body name",
+                                  |  "consignmentReference" : "consignment reference",
+                                  |  "consignmentId" : "consignment id",
+                                  |  "userId" : "user id",
+                                  |  "userEmail" : "user@email",
+                                  |  "status" : "some status"
+                                  |}""".stripMargin
+
+    service.sendUploadEventUserEmail(event)
+    verify(mockSnsUtils).publish(expectedMessageString, "user-email-sns-topic")
+  }
+}


### PR DESCRIPTION
Generic service to support sending messages

Initially to support user emails to notify that a SharePoint upload has completed