### PR TITLE
Check user is assigned to a transferring body

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,14 +5,14 @@ object Dependencies {
   private val mockitoVersion = "2.2.1"
   private val pureConfigVersion = "0.17.10"
   private val tapirVersion = "1.13.16"
-  private val awsUtilsVersion = "0.1.327"
+  private val awsUtilsVersion = "0.1.328"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.283"
 
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.7.0"
 
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.467"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.292"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.469"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.293"
 
   lazy val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   lazy val http4sEmberServer = "org.http4s" %% "http4s-ember-server" % http4sVersion
@@ -35,7 +35,7 @@ object Dependencies {
   lazy val tapirHttp4sServer = "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion
   lazy val tapirJsonCirce = "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion
   lazy val tapirSwaggerUI = "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion
-  lazy val tdrAuthorisation = "uk.gov.nationalarchives" %% "tdr-authorisation" % "0.0.14"
+  lazy val tdrAuthorisation = "uk.gov.nationalarchives" %% "tdr-authorisation" % "0.0.15"
 
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,29 +2,29 @@ import sbt.*
 
 object Dependencies {
   private val http4sVersion = "0.23.34"
-  private val mockitoVersion = "2.1.0"
+  private val mockitoVersion = "2.2.1"
   private val pureConfigVersion = "0.17.10"
   private val tapirVersion = "1.13.15"
   private val awsUtilsVersion = "0.1.324"
 
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.282"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.283"
 
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.7.0"
 
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.467"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.290"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.292"
 
   lazy val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   lazy val http4sEmberServer = "org.http4s" %% "http4s-ember-server" % http4sVersion
   lazy val http4sDsl = "org.http4s" %% "http4s-dsl" % http4sVersion
 
-  lazy val keycloakAdminClient = "org.keycloak" % "keycloak-admin-client" % "26.0.8"
+  lazy val keycloakAdminClient = "org.keycloak" % "keycloak-admin-client" % "26.0.9"
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.20.0"
 
   lazy val logBackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "9.0"
   lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.5.32"
 
-  lazy val metadataSchema = "uk.gov.nationalarchives" %% "da-metadata-schema" % "0.0.128"
+  lazy val metadataSchema = "uk.gov.nationalarchives" %% "da-metadata-schema" % "0.0.129"
   lazy val mockito = "org.mockito" %% "mockito-scala" % mockitoVersion
   lazy val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoVersion
 
@@ -35,7 +35,7 @@ object Dependencies {
   lazy val tapirHttp4sServer = "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion
   lazy val tapirJsonCirce = "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion
   lazy val tapirSwaggerUI = "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion
-  lazy val tdrAuthorisation = "uk.gov.nationalarchives" %% "tdr-authorisation" % "0.0.10"
+  lazy val tdrAuthorisation = "uk.gov.nationalarchives" %% "tdr-authorisation" % "0.0.14"
 
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.20"

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticator.scala
@@ -29,14 +29,19 @@ class TokenAuthenticator()(implicit logger: SelfAwareStructuredLogger[IO]) {
     IO {
       KeycloakUtils().token(bearer) match {
         case Right(t) if t.isStandardUser && t.transferringBody.nonEmpty => Right(AuthenticatedContext(t))
-        case Right(t) if t.transferringBody.isEmpty                      =>
+        case Right(t) if !t.isStandardUser                               =>
+          Left {
+            val errorMessage = s"User ${t.userId} is not a standard user"
+            authenticationErrorHandler(errorMessage)
+          }
+        case Right(t) if t.transferringBody.isEmpty =>
           Left {
             val errorMessage = s"User ${t.userId} is misconfigured"
             authenticationErrorHandler(errorMessage)
           }
         case Right(t) =>
           Left {
-            val errorMessage = s"User ${t.userId} is not a standard user"
+            val errorMessage = s"User ${t.userId} does not have access"
             authenticationErrorHandler(errorMessage)
           }
         case Left(e) =>

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticator.scala
@@ -20,20 +20,28 @@ class TokenAuthenticator()(implicit logger: SelfAwareStructuredLogger[IO]) {
   implicit val tdrKeycloakDeployment: TdrKeycloakDeployment =
     TdrKeycloakDeployment(s"$authUrl", realm, 8080)
 
+  private def authenticationErrorHandler(errorMessage: String, errorType: String = "Authorisation"): AuthenticationError = {
+    logger.info(s"$errorType error: $errorMessage")
+    AuthenticationError(errorMessage)
+  }
+
   def authenticateStandardUserToken(bearer: String): IO[Either[AuthenticationError, AuthenticatedContext]] = {
     IO {
       KeycloakUtils().token(bearer) match {
-        case Right(t) if t.isStandardUser => Right(AuthenticatedContext(t))
-        case Right(t)                     =>
+        case Right(t) if t.isStandardUser && t.transferringBody.nonEmpty => Right(AuthenticatedContext(t))
+        case Right(t) if t.transferringBody.isEmpty                      =>
+          Left {
+            val errorMessage = s"User ${t.userId} is misconfigured"
+            authenticationErrorHandler(errorMessage)
+          }
+        case Right(t) =>
           Left {
             val errorMessage = s"User ${t.userId} is not a standard user"
-            logger.info(s"Authorisation error: $errorMessage")
-            AuthenticationError(errorMessage)
+            authenticationErrorHandler(errorMessage)
           }
         case Left(e) =>
           Left {
-            logger.info(s"Authentication error: ${e.getMessage}")
-            AuthenticationError(e.getMessage)
+            authenticationErrorHandler(e.getMessage, "Authentication")
           }
       }
     }

--- a/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/TestUtils.scala
@@ -13,17 +13,18 @@ object TestUtils {
   val userId: UUID = UUID.fromString("4ab14990-ed63-4615-8336-56fbb9960300")
   val transferServiceUserId = UUID.fromString("f67d1337-cbd0-4fd1-9eac-611489e7113f")
 
-  def validUserToken(userId: UUID = userId, body: String = "Code", standardUser: String = "true"): OAuth2BearerToken =
-    OAuth2BearerToken(
-      tdrKeycloakMock.getAccessToken(
-        aTokenConfig()
-          .withResourceRole("tdr", "tdr_user")
-          .withClaim("body", body)
-          .withClaim("user_id", userId)
-          .withClaim("standard_user", standardUser)
-          .build
-      )
-    )
+  def validUserToken(userId: UUID = userId, body: Option[String] = Some("Code"), standardUser: String = "true"): OAuth2BearerToken = {
+    val tokenBuilder = aTokenConfig()
+      .withResourceRole("tdr", "tdr_user")
+      .withClaim("user_id", userId)
+      .withClaim("standard_user", standardUser)
+
+    if (body.nonEmpty) {
+      tokenBuilder.withClaim("body", body.get)
+    }
+
+    OAuth2BearerToken(tdrKeycloakMock.getAccessToken(tokenBuilder.build()))
+  }
 
   def validClientToken(clientId: String = "tdr-transfer-service", role: String = "data-load"): OAuth2BearerToken =
     OAuth2BearerToken(

--- a/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/TestUtils.scala
@@ -11,7 +11,7 @@ object TestUtils {
   private val testKeycloakMock: KeycloakMock = createServer("test", 8001)
 
   val userId: UUID = UUID.fromString("4ab14990-ed63-4615-8336-56fbb9960300")
-  val transferServiceUserId = UUID.fromString("f67d1337-cbd0-4fd1-9eac-611489e7113f")
+  val transferServiceUserId: UUID = UUID.fromString("f67d1337-cbd0-4fd1-9eac-611489e7113f")
 
   def validUserToken(userId: UUID = userId, body: Option[String] = Some("Code"), standardUser: String = "true"): OAuth2BearerToken = {
     val tokenBuilder = aTokenConfig()

--- a/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticatorSpec.scala
@@ -30,7 +30,7 @@ class TokenAuthenticatorSpec extends BaseSpec {
     val validToken = validUserToken(body = None, standardUser = "false")
     val response = TokenAuthenticator().authenticateStandardUserToken(validToken.token).unsafeRunSync()
 
-    response.left.toOption.get.message shouldBe s"User $userId is misconfigured"
+    response.left.toOption.get.message shouldBe s"User $userId is not a standard user"
   }
 
   "'authenticateStandardUserToken'" should "return authentication error when token invalid" in {

--- a/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/api/auth/TokenAuthenticatorSpec.scala
@@ -19,6 +19,20 @@ class TokenAuthenticatorSpec extends BaseSpec {
     response.left.toOption.get.message shouldBe s"User $userId is not a standard user"
   }
 
+  "'authenticateStandardUserToken'" should "return authentication error when a standard user is not assigned to a transferring body" in {
+    val validToken = validUserToken(body = None)
+    val response = TokenAuthenticator().authenticateStandardUserToken(validToken.token).unsafeRunSync()
+
+    response.left.toOption.get.message shouldBe s"User $userId is misconfigured"
+  }
+
+  "'authenticateStandardUserToken'" should "return authentication error when a non-standard user is not assigned to a transferring body" in {
+    val validToken = validUserToken(body = None, standardUser = "false")
+    val response = TokenAuthenticator().authenticateStandardUserToken(validToken.token).unsafeRunSync()
+
+    response.left.toOption.get.message shouldBe s"User $userId is misconfigured"
+  }
+
   "'authenticateStandardUserToken'" should "return authentication error when token invalid" in {
     val token = invalidToken
     val response = TokenAuthenticator().authenticateStandardUserToken(token.token).unsafeRunSync()


### PR DESCRIPTION
Prevent a user from transferring from a client unless assigned a transferring body

Ensures that Series page shows list of series to assign to the created consignment