### PR TITLE
Can't have a comma (',') in ECS task definition env var

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,14 +5,14 @@ object Dependencies {
   private val mockitoVersion = "2.2.1"
   private val pureConfigVersion = "0.17.10"
   private val tapirVersion = "1.13.19"
-  private val awsUtilsVersion = "0.1.330"
+  private val awsUtilsVersion = "0.1.331"
 
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.286"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.289"
 
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.7.0"
 
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.473"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.300"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.476"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.302"
 
   lazy val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   lazy val http4sEmberServer = "org.http4s" %% "http4s-ember-server" % http4sVersion
@@ -22,7 +22,7 @@ object Dependencies {
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.20.0"
 
   lazy val logBackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "9.0"
-  lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.5.32"
+  lazy val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.5.33"
 
   lazy val metadataSchema = "uk.gov.nationalarchives" %% "da-metadata-schema" % "0.0.131"
   lazy val mockito = "org.mockito" %% "mockito-scala" % mockitoVersion
@@ -35,7 +35,7 @@ object Dependencies {
   lazy val tapirHttp4sServer = "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion
   lazy val tapirJsonCirce = "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion
   lazy val tapirSwaggerUI = "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion
-  lazy val tdrAuthorisation = "uk.gov.nationalarchives" %% "tdr-authorisation" % "0.0.23"
+  lazy val tdrAuthorisation = "uk.gov.nationalarchives" %% "tdr-authorisation" % "0.0.26"
 
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.20"

--- a/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/services/dataload/DataLoadProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/transfer/service/services/dataload/DataLoadProcessor.scala
@@ -16,7 +16,7 @@ import java.util.UUID
 class DataLoadProcessor(messageService: Messages, appConfig: ApplicationConfig.Configuration)(implicit logger: SelfAwareStructuredLogger[IO]) {
   def trigger(event: DataLoadProcessorEvent, token: Token): IO[LoadCompletionResponse] = {
     val metadataSourceBucket = appConfig.s3.metadataUploadBucketName
-    val ignoreSiteNameBodies = appConfig.transferConfiguration.ignoreSiteNameBodies.split(",").toSet
+    val ignoreSiteNameBodies = appConfig.transferConfiguration.ignoreSiteNameBodies.split(";").toSet
     val ignoreSiteName = ignoreSiteNameBodies.contains(token.transferringBody.get)
     val transferId = event.transferId
     val details = event.loadCompletionDetails

--- a/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/services/dataload/DataLoadProcessorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tdr/transfer/service/services/dataload/DataLoadProcessorSpec.scala
@@ -52,7 +52,7 @@ class DataLoadProcessorSpec extends BaseSpec {
     val transferIdArgumentCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
     val eventArgumentCaptor: ArgumentCaptor[AggregateProcessingEvent] = ArgumentCaptor.forClass(classOf[AggregateProcessingEvent])
 
-    mockResponses(ignoreSiteNameBodies = "TDR-BODY1,TDR-BODY2")
+    mockResponses(ignoreSiteNameBodies = "TDR-BODY1;TDR-BODY2")
 
     when(mockMessageService.sendAggregateProcessingEventMessage(transferIdArgumentCaptor.capture(), eventArgumentCaptor.capture()))
       .thenReturn(SendMessageResponse.builder().build())


### PR DESCRIPTION
Use semi-colon (`;`) as list delimiter instead